### PR TITLE
Updated AWS Provider and Nodejs runtime to nodejs18.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.9"
     }
   }
 }

--- a/modules/non-free-resources/lambda/lambda.tf
+++ b/modules/non-free-resources/lambda/lambda.tf
@@ -33,7 +33,7 @@ resource "aws_lambda_function" "test_lambda" {
   role             = aws_iam_role.privesc-high-priv-lambda-role2.arn
   handler          = "index.handler"
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
-  runtime          = "nodejs12.x"
+  runtime          = "nodejs18.x"
 }
 resource "aws_iam_role" "privesc-high-priv-lambda-role2" {
   name                = "privesc-high-priv-lambda-role2"


### PR DESCRIPTION
#### Card

#### Details
The previous nodejs runtime was no longer supported in AWS lambda, in order to update the resources I used a newer AWS provider and changed the runtime in the lambda module